### PR TITLE
Fix case entry edit page JS selector

### DIFF
--- a/GoalsTracker/Pages/EditCaseEntry.cshtml
+++ b/GoalsTracker/Pages/EditCaseEntry.cshtml
@@ -26,7 +26,7 @@
 
 <script>
     const form = document.querySelector('form');
-    const input = document.querySelector('[name="Entry.cases closedWorked"]');
+    const input = document.querySelector('[name="Entry.CasesClosed"]');
 
     // Save the original numeric value on page load
     const originalValue = input.value.replace(' cases closed', '').trim();


### PR DESCRIPTION
## Summary
- fix JS selector for `Entry.CasesClosed` field in edit case page

## Testing
- `dotnet build GoalsTracker.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68895ac3173c83219e7ac21d499fc823